### PR TITLE
Add YuMincho for macOS compatibility

### DIFF
--- a/template.typ
+++ b/template.typ
@@ -12,7 +12,7 @@
   // General settings
   set document(author: authors.map(a => a.name-ja), title: title-ja)
   // Prioritize YuMincho because MS Mincho does not support bold.
-  set text(font: ("Times New Roman", "Yu Mincho", "MS Mincho"), lang: "ja")
+  set text(font: ("Times New Roman", "Yu Mincho", "YuMincho", "MS Mincho"), lang: "ja")
   set page(paper: "a4", margin: (x: 23mm, y: 25mm))
 
   // Heading settings


### PR DESCRIPTION
This PR adds `YuMincho` in addition to `Yu Mincho` (with a space) for macOS compatibility.